### PR TITLE
fix: add immutable deploymentBlock to contract and update verification logic

### DIFF
--- a/moonbeam-raffle/contracts/LocalVRFRaffle.sol
+++ b/moonbeam-raffle/contracts/LocalVRFRaffle.sol
@@ -21,6 +21,7 @@ contract LocalVRFRaffle is ReentrancyGuard, Pausable, Ownable(msg.sender) {
     uint256 public constant MAX_PARTICIPANTS = 1000;
     uint256 public constant MIN_PARTICIPANTS = 3;
     uint256 private immutable BLOCKS_UNTIL_DRAW;
+    uint256 public immutable deploymentBlock;
 
     // Structures
     struct DrawingResult {
@@ -65,6 +66,7 @@ contract LocalVRFRaffle is ReentrancyGuard, Pausable, Ownable(msg.sender) {
         
         participantIds = _participantIds;
         BLOCKS_UNTIL_DRAW = _blocksUntilDraw;
+        deploymentBlock = block.number;
         targetBlock = block.number + _blocksUntilDraw;
         commitHash = _commitHash;
         authorizedDrawers[msg.sender] = true;


### PR DESCRIPTION
- Add immutable deploymentBlock variable to LocalVRFRaffle contract to store deployment block number
- Remove event-based deployment block retrieval in VerifyButton component
- Replace event search logic with direct contract call to get deployment block
- Simplify verification process by using immutable contract state
- Ensure deployment block number remains constant throughout contract lifecycle

This change fixes the issue where the deployment block number was incorrectly changing after several days due to event search limitations. The new implementation provides a more reliable and gas-efficient way to track the contract's deployment block.